### PR TITLE
Removing getDOMNode call, which is now deprecated

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -24,7 +24,7 @@ class Greeter extends React.Component {
   }
 
   handleGreet() {
-    this.setState({ name: this.refs.name.getDOMNode().value });
+    this.setState({ name: this.refs.name.value });
   }
 
   componentWillMount() {


### PR DESCRIPTION
noticed the error in the console window after transpiling and refreshing the page
