### PR TITLE
running flow with no errors now

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,5 +1,7 @@
 [ignore]
 .*/node_modules/node-sass/.*
+.*/node_modules/fbjs.*
+.*/node_modules/npmconf.*
 .*/src/.*
 
 [include]


### PR DESCRIPTION
Added two lines to the .flowconfig ignore section.  Not sure if that was the right way to fix these errors:

node_modules/npmconf/test/fixtures/package.json:1
  1: 
       ^ Unexpected end of input

node_modules/react/node_modules/fbjs/flow/include/Deferred.js:14
 14: var Promise = require('Promise');
                   ^^^^^^^^^^^^^^^^^^ Promise. Required module not found

node_modules/react/node_modules/fbjs/flow/include/PromiseMap.js:15
 15: var Deferred = require('Deferred');
                    ^^^^^^^^^^^^^^^^^^^ Deferred. Required module not found

node_modules/react/node_modules/fbjs/flow/include/PromiseMap.js:17
 17: var invariant = require('invariant');
                     ^^^^^^^^^^^^^^^^^^^^ invariant. Required module not found

node_modules/react/node_modules/fbjs/flow/include/PromiseMap.js:19
 19: import type \* as Promise from 'Promise';
                                   ^^^^^^^^^ Promise. Required module not found

node_modules/react/node_modules/fbjs/flow/include/fetchWithRetries.js:16
 16: var ExecutionEnvironment = require('ExecutionEnvironment');
                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ExecutionEnvironment. Required module not found

node_modules/react/node_modules/fbjs/flow/include/fetchWithRetries.js:17
 17: var Promise = require('Promise');
                   ^^^^^^^^^^^^^^^^^^ Promise. Required module not found

node_modules/react/node_modules/fbjs/flow/include/fetchWithRetries.js:19
 19: var sprintf = require('sprintf');
                   ^^^^^^^^^^^^^^^^^^ sprintf. Required module not found

node_modules/react/node_modules/fbjs/flow/include/fetchWithRetries.js:20
 20: var fetch = require('fetch');
                 ^^^^^^^^^^^^^^^^ fetch. Required module not found

node_modules/react/node_modules/fbjs/flow/include/fetchWithRetries.js:21
 21: var warning = require('warning');
                   ^^^^^^^^^^^^^^^^^^ warning. Required module not found

node_modules/react/node_modules/fbjs/flow/include/resolveImmediate.js:13
 13: var Promise = require('Promise');
                   ^^^^^^^^^^^^^^^^^^ Promise. Required module not found
